### PR TITLE
Adding "lazy" save case when no meshes were ever loaded

### DIFF
--- a/urchin/urdf.py
+++ b/urchin/urdf.py
@@ -710,12 +710,13 @@ class Mesh(URDFTypeWithMesh):
         fn = get_filename(path, self.filename, makedirs=True)
 
         # Export the meshes as a single file
-        meshes = self.meshes
-        if len(meshes) == 1:
-            meshes = meshes[0]
-        elif os.path.splitext(fn)[1] == ".glb":
-            meshes = trimesh.scene.Scene(geometry=meshes)
-        trimesh.exchange.export.export_mesh(meshes, fn)
+        if self._meshes is not None:
+            meshes = self.meshes
+            if len(meshes) == 1:
+                meshes = meshes[0]
+            elif os.path.splitext(fn)[1] == ".glb":
+                meshes = trimesh.scene.Scene(geometry=meshes)
+            trimesh.exchange.export.export_mesh(meshes, fn)
 
         # Unparse the node
         node = self._unparse(path)


### PR DESCRIPTION
I encountered permission issues on mesh files when calling the `save()` method when no meshes were ever loaded in my code (using the `lazy_load` argument). 

The problem was fixed by adding a check in the `Mesh` class `to_xml()` method, and works like a charm on my side :)

Thank you for maintaining urdfpy alive !