### PR TITLE
Fix AttributeError for older style transmission types.

### DIFF
--- a/urchin/urdf.py
+++ b/urchin/urdf.py
@@ -2076,7 +2076,13 @@ class Transmission(URDFType):
     @classmethod
     def _from_xml(cls, node, path):
         kwargs = cls._parse(node, path)
-        kwargs["trans_type"] = node.find("type").text
+        try:
+            trans_type = node.attrib.get('type')
+            if trans_type is None:
+                trans_type = node.find("type").text
+            kwargs["trans_type"] = trans_type
+        except AttributeError:
+            kwargs["trans_type"] = ''
         return Transmission(**kwargs)
 
     def _to_xml(self, parent, path):


### PR DESCRIPTION
Addresses issue #9 using the fix described within that issue.

This fix also makes the transmission type optional which may or may not be a problem. If it should not be optional, I can remove the try-except block surrounding the updated code.