### PR TITLE
Extrinsic angles for rpy values encoding

### DIFF
--- a/urchin/utils.py
+++ b/urchin/utils.py
@@ -6,6 +6,7 @@ from lxml import etree as ET
 import numpy as np
 import trimesh
 
+from scipy.spatial.transform import Rotation 
 
 def rpy_to_matrix(coords):
     """Convert roll-pitch-yaw coordinates to a 3x3 homogenous rotation matrix.
@@ -13,10 +14,9 @@ def rpy_to_matrix(coords):
     The roll-pitch-yaw axes in a typical URDF are defined as a
     rotation of ``r`` radians around the x-axis followed by a rotation of
     ``p`` radians around the y-axis followed by a rotation of ``y`` radians
-    around the z-axis. These are the Z1-Y2-X3 Tait-Bryan angles. See
-    Wikipedia_ for more information.
+    around the z-axis. These are extrinsic transformation according to ROS:
+    https://wiki.ros.org/geometry2/RotationMethods
 
-    .. _Wikipedia: https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
 
     Parameters
     ----------
@@ -28,66 +28,29 @@ def rpy_to_matrix(coords):
     R : (3,3) float
         The corresponding homogenous 3x3 rotation matrix.
     """
-    coords = np.asanyarray(coords, dtype=np.float64)
-    c3, c2, c1 = np.cos(coords)
-    s3, s2, s1 = np.sin(coords)
-
-    return np.array([
-        [c1 * c2, (c1 * s2 * s3) - (c3 * s1), (s1 * s3) + (c1 * c3 * s2)],
-        [c2 * s1, (c1 * c3) + (s1 * s2 * s3), (c3 * s1 * s2) - (c1 * s3)],
-        [-s2, c2 * s3, c2 * c3]
-    ], dtype=np.float64)
+    return Rotation.from_euler("xyz", coords).as_matrix()
 
 
-def matrix_to_rpy(R, solution=1):
+def matrix_to_rpy(R):
     """Convert a 3x3 transform matrix to roll-pitch-yaw coordinates.
 
     The roll-pitchRyaw axes in a typical URDF are defined as a
     rotation of ``r`` radians around the x-axis followed by a rotation of
     ``p`` radians around the y-axis followed by a rotation of ``y`` radians
-    around the z-axis. These are the Z1-Y2-X3 Tait-Bryan angles. See
-    Wikipedia_ for more information.
-
-    .. _Wikipedia: https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix
-
-    There are typically two possible roll-pitch-yaw coordinates that could have
-    created a given rotation matrix. Specify ``solution=1`` for the first one
-    and ``solution=2`` for the second one.
+    around the z-axis. These are extrinsic transformation according to ROS:
+    https://wiki.ros.org/geometry2/RotationMethods
 
     Parameters
     ----------
     R : (3,3) float
         A 3x3 homogenous rotation matrix.
-    solution : int
-        Either 1 or 2, indicating which solution to return.
-
+    
     Returns
     -------
     coords : (3,) float
         The roll-pitch-yaw coordinates in order (x-rot, y-rot, z-rot).
     """
-    R = np.asanyarray(R, dtype=np.float64)
-    r = 0.0
-    p = 0.0
-    y = 0.0
-
-    if np.abs(R[2,0]) >= 1.0 - 1e-12:
-        y = 0.0
-        if R[2,0] < 0:
-            p = np.pi / 2
-            r = np.arctan2(R[0,1], R[0,2])
-        else:
-            p = -np.pi / 2
-            r = np.arctan2(-R[0,1], -R[0,2])
-    else:
-        if solution == 1:
-            p = -np.arcsin(R[2,0])
-        else:
-            p = np.pi + np.arcsin(R[2,0])
-        r = np.arctan2(R[2,1] / np.cos(p), R[2,2] / np.cos(p))
-        y = np.arctan2(R[1,0] / np.cos(p), R[0,0] / np.cos(p))
-
-    return np.array([r, p, y], dtype=np.float64)
+    return Rotation.from_matrix(coords).as_euler("xyz")
 
 
 def matrix_to_xyz_rpy(matrix):


### PR DESCRIPTION
I propose to use extrinsic angle decoding of fixed transforms with `rpy`. This is according to the convention defined by ROS for rpy:
https://wiki.ros.org/geometry2/RotationMethods

And also how other libraries such as MoveIt uses them:
https://github.com/moveit/moveit_calibration/pull/47/commits/b7148d75c1a14ebf50335a3aaa051b140e6fdc0e

Additionally, I use the `Rotation` class form scipy, as that make the code much simpler. However, this implied that the result option is not possible for the back-conversion.