### PR TITLE
Fix export of color in material that is not child of robot tag

### DIFF
--- a/urchin/urdf.py
+++ b/urchin/urdf.py
@@ -1054,10 +1054,13 @@ class Material(URDFType):
                 color.attrib["rgba"] = np.array2string(self.color)[1:-1]
                 node.append(color)
 
-        # For non-top-level elements just save the material with a name
         else:
             node = ET.Element("material")
             node.attrib["name"] = self.name
+            if self.color is not None:
+                color = ET.Element("color")
+                color.attrib["rgba"] = np.array2string(self.color)[1:-1]
+                node.append(color)
         return node
 
     def copy(self, prefix="", scale=None):


### PR DESCRIPTION
It seems that the current version of `urchin` does not export the `<color>` tag of `<material>` element if the `<material>` is not child of `<robot>`. However, the URDF spec fully support the case in which the color of a `<material>` is child of a `<link>` tag, see the example in http://wiki.ros.org/urdf/XML/link .

