### PR TITLE
Bump version to 0.0.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ docs_requirements = [
 
 setup(
     name="urchin",
-    version="0.0.27",
+    version="0.0.29",
     description="URDF parser and manipulator for Python",
     long_description="URDF parser and manipulator for Python. This package is a fork of urdfpy, which seems to be no longer maintained. ",
     author="Adam Fishman",


### PR DESCRIPTION
Fix https://github.com/fishbotics/urchin/issues/19 .

Sorry @fishbotics, I forgot to bump the version number in the latest PR so that we can do a release.