### PR TITLE
requirements.txt: Change pyrender to pyribbit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ networkx
 numpy
 pillow
 pycollada
-pyrender
+pyribbit
 six
 trimesh
 sphinx


### PR DESCRIPTION
Originally proposed in https://github.com/fishbotics/urchin/pull/21 . Eventually we can just remove the `requirements.txt`, but as long as it is there it make sense to keep it updated.