### PR TITLE
Introduce batch fk capabilities for floating and planar joints

### DIFF
--- a/urchin/urdf.py
+++ b/urchin/urdf.py
@@ -2388,37 +2388,23 @@ class Joint(URDFType):
         elif self.joint_type == "fixed":
             return self.origin
         elif self.joint_type in ["revolute", "continuous"]:
-            if cfg is None:
-                cfg = 0.0
-            else:
-                cfg = float(cfg)
+            cfg = float(cfg)
             R = trimesh.transformations.rotation_matrix(cfg, self.axis)
             return self.origin.dot(R)
         elif self.joint_type == "prismatic":
-            if cfg is None:
-                cfg = 0.0
-            else:
-                cfg = float(cfg)
+            cfg = float(cfg)
             translation = np.eye(4, dtype=np.float64)
             translation[:3, 3] = self.axis * cfg
             return self.origin.dot(translation)
         elif self.joint_type == "planar":
-            if cfg is None:
-                cfg = np.zeros(2, dtype=np.float64)
-            else:
-                cfg = np.asanyarray(cfg, dtype=np.float64)
+            cfg = np.asanyarray(cfg, dtype=np.float64)
             if cfg.shape != (2,):
                 raise ValueError("(2,) float configuration required for planar joints")
             translation = np.eye(4, dtype=np.float64)
             translation[:3, 3] = self.origin[:3, :2].dot(cfg)
             return self.origin.dot(translation)
         elif self.joint_type == "floating":
-            if cfg is None:
-                cfg = np.zeros(6, dtype=np.float64)
-            else:
-                cfg = configure_origin(cfg)
-            if cfg is None:
-                raise ValueError("Invalid configuration for floating joint")
+            cfg = configure_origin(cfg)
             return self.origin.dot(cfg)
         else:
             raise ValueError("Invalid configuration")
@@ -2454,12 +2440,8 @@ class Joint(URDFType):
         elif self.joint_type == "fixed":
             return np.tile(self.origin, (n_cfgs, 1, 1))
         elif self.joint_type in ["revolute", "continuous"]:
-            if cfg is None:
-                cfg = np.zeros(n_cfgs)
             return np.matmul(self.origin, self._rotation_matrices(cfg, self.axis))
         elif self.joint_type == "prismatic":
-            if cfg is None:
-                cfg = np.zeros(n_cfgs)
             translation = np.tile(np.eye(4), (n_cfgs, 1, 1))
             translation[:, :3, 3] = self.axis * cfg[:, np.newaxis]
             return np.matmul(self.origin, translation)

--- a/urchin/urdf.py
+++ b/urchin/urdf.py
@@ -4088,7 +4088,9 @@ class URDF(URDFTypeWithMesh):
                             eidx = sidx + 6
                         else:
                             eidx = sidx + 1
-                        joint_cfg[j] = cfgs[:, sidx:eidx].squeeze()
+                        joint_cfg[j] = cfgs[:, sidx:eidx]
+                        if joint_cfg[j].shape[-1] == 1:
+                            joint_cfg[j] = joint_cfg[j].squeeze(-1)
                         sidx = eidx
         else:
             raise ValueError("Incorrectly formatted config array")


### PR DESCRIPTION
Hello, it seemed like urchin's batched forwards kinematics functions didn't have support for planar and floating joints. I went through updated the relevant functions to add that support. To also simplify the forwards kinematics for those two joint types, I added functionality that would unpack a flat list or numpy array to the corresponding 2dof or 6dof inputs for those joints.

So, if you have a planar joint followed by a revolute joint, you can now do [x_val, y_val, rot_val] as your list input instead of [[x_val, y_val], rot_val], which helps with the numpy batching form for forward kinematics.

I also noticed that there were extra None type checks in `get_child_pose` and `get_child_poses`, so I also went ahead and removed those in one of those commits, but if that's a no-go, I can remove that commit.